### PR TITLE
Fix composer.json dependencies for new release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.1",
-        "symfony/dependency-injection": "2.1"
+        "symfony/framework-bundle": "2.1.*",
+        "symfony/dependency-injection": "2.1.*"
     },
     "autoload":     {
         "psr-0": { "Lexik\\Bundle\\MaintenanceBundle": "" }


### PR DESCRIPTION
With current setup I keep getting error because of how strict dependency version is set

```
  Problem 1
    - Installation request for lexik/maintenance-bundle dev-master -> satisfiable by lexik/maintenance-bundle dev-master.
    - Conclusion: remove symfony/symfony 2.1.x-dev
    - don't install symfony/symfony dev-master|don't install symfony/symfony 2.1.x-dev
    - Can only install one of: symfony/symfony 2.1.x-dev, symfony/symfony dev-master.
    - Installation request for symfony/symfony == 2.1.9999999.9999999-dev -> satisfiable by symfony/symfony 2.1.x-dev.
    - Installation request for symfony/symfony == 9999999-dev -> satisfiable by symfony/symfony dev-master.
```
