### PR TITLE
Update dependencies to allow use with Symfony 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.1.*",
-        "symfony/dependency-injection": "2.1.*"
+        "symfony/framework-bundle": ">=2.1,<2.3-dev",
+        "symfony/dependency-injection": ">=2.1,<2.3-dev"
     },
     "autoload":     {
         "psr-0": { "Lexik\\Bundle\\MaintenanceBundle": "" }


### PR DESCRIPTION
Update dependencies in composer.json to allow for symfony 2.2 in addition to 2.1.
