### PR TITLE
  Fix #19, add test on RouteFilter, debug dev environnement with routeFilter

### DIFF
--- a/Listener/MaintenanceListener.php
+++ b/Listener/MaintenanceListener.php
@@ -31,15 +31,56 @@ class MaintenanceListener
      * @var array
      */
     protected $authorizedIps;
+
+    /**
+     * @var null|String
+     */
     protected $path;
+
+    /**
+     * @var null|String
+     */
     protected $host;
+
+    /**
+     * @var array|null
+     */
     protected $ips;
+
+    /**
+     * @var array
+     */
     protected $query;
+
+    /**
+     * @var null|String
+     */
     protected $route;
+
+    /**
+     * @var array
+     */
     protected $attributes;
+
+    /**
+     * @var Int|null
+     */
     protected $http_code;
+
+    /**
+     * @var null|String
+     */
     protected $http_status;
+
+    /**
+     * @var bool
+     */
     protected $handleResponse = false;
+
+    /**
+     * @var bool
+     */
+    protected $debug;
 
     /**
      * Constructor Listener
@@ -60,8 +101,18 @@ class MaintenanceListener
      * @param Int $http_code http status code for response
      * @param String $http_status http status message for response
      */
-    public function __construct(DriverFactory $driverFactory, $path = null, $host = null, $ips = null, $query = array(), $route = null, $attributes = array(), $http_code = null, $http_status = null)
-    {
+    public function __construct(
+        DriverFactory $driverFactory,
+        $path = null,
+        $host = null,
+        $ips = null,
+        $query = array(),
+        $route = null,
+        $attributes = array(),
+        $http_code = null,
+        $http_status = null,
+        $debug = false
+    ) {
         $this->driverFactory = $driverFactory;
         $this->path = $path;
         $this->host = $host;
@@ -71,6 +122,7 @@ class MaintenanceListener
         $this->attributes = $attributes;
         $this->http_code = $http_code;
         $this->http_status = $http_status;
+        $this->debug = $debug;
     }
 
     /**
@@ -112,7 +164,8 @@ class MaintenanceListener
             return;
         }
 
-        if (null !== $this->route && !preg_match('{'.$this->route.'}', $request->get('_route'))) {
+        $route = $request->get('_route');
+        if (null !== $this->route && preg_match('{'.$this->route.'}', $route)  || (true === $this->debug && '_' === $route[0])) {
             return;
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -28,6 +28,7 @@
             <argument>%lexik_maintenance.authorized.attributes%</argument>
             <argument>%lexik_maintenance.response.http_code%</argument>
             <argument>%lexik_maintenance.response.http_status%</argument>
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Fix ticket #19, now the test allow route passed via configTreeBuilder and do not deny.

Other thing, I inject the kernel.debug in order to correctly test the behavior in dev environnement when you restrict with route because some troubles are causes by the WebDebugProfiler component. The ajax request on `_profiler` cause bug because `_profiler` is hit and not allowed. In order to fix this i just ignore route starting with `_` when debug is true only (so that allow to have underscored route in production).

BTW I have add test on the route filter logic to avoid regression and be sure it's work.

**Can you track pull request with Travis please ? This helpful to check supported php version**
