### PR TITLE
Fix namespace/database error when using databaseDriver

### DIFF
--- a/Drivers/Query/DefaultQuery.php
+++ b/Drivers/Query/DefaultQuery.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\EntityManager;
  * @package LexikMaintenanceBundle
  * @author  Gilles Gauthier <g.gauthier@lexik.fr>
  */
-class DefaultQuery extends PdoDriver
+class DefaultQuery extends PdoQuery
 {
     /**
      * @var EntityManager


### PR DESCRIPTION
certainly forgot to update a class name.
Works better with this change.