### PR TITLE
Avoid the database driver to try to create the maintenance table at every request

### DIFF
--- a/Drivers/DatabaseDriver.php
+++ b/Drivers/DatabaseDriver.php
@@ -58,9 +58,9 @@ class DatabaseDriver extends AbstractDriver implements DriverTtlInterface
             $this->pdoDriver = new DsnQuery($this->options);
         } else {
             if (isset($this->options['connection'])) {
-                $this->pdoDriver = new DefaultQuery($this->doctrine->getManager($this->options['connection']));
+                $this->pdoDriver = new DefaultQuery($this->doctrine->getManager($this->options['connection']), $this->options);
             } else {
-                $this->pdoDriver = new DefaultQuery($this->doctrine->getManager());
+                $this->pdoDriver = new DefaultQuery($this->doctrine->getManager(), $this->options);
             }
         }
     }

--- a/Drivers/Query/DefaultQuery.php
+++ b/Drivers/Query/DefaultQuery.php
@@ -20,11 +20,13 @@ class DefaultQuery extends PdoQuery
     const NAME_TABLE   = 'lexik_maintenance';
 
     /**
-     * @param EntityManager $em Entity Manager
+     * @param EntityManager $em      Entity Manager
+     * @param array         $options Options driver
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManager $em, array $options = array())
     {
         $this->em = $em;
+        parent::__construct($options);
     }
 
     /**
@@ -35,7 +37,9 @@ class DefaultQuery extends PdoQuery
         if (null === $this->db) {
             $db = $this->em->getConnection();
             $this->db = $db;
-            $this->createTableQuery();
+            if (!isset($this->options['table_created']) || !$this->options['table_created']) {
+                $this->createTableQuery();
+            }
         }
 
         return $this->db;

--- a/Drivers/Query/DsnQuery.php
+++ b/Drivers/Query/DsnQuery.php
@@ -18,14 +18,15 @@ class DsnQuery extends PdoQuery
     public function initDb()
     {
         if (null === $this->db) {
-
             if (!class_exists('PDO') || !in_array('mysql', \PDO::getAvailableDrivers(), true)) {
                 throw new \RuntimeException('You need to enable PDO_Mysql extension for the profiler to run properly.');
             }
 
             $db = new \PDO($this->options['dsn'], $this->options['user'], $this->options['password']);
             $this->db = $db;
-            $this->createTableQuery();
+            if (!isset($this->options['table_created']) || !$this->options['table_created']) {
+                $this->createTableQuery();
+            }
         }
 
         return $this->db;


### PR DESCRIPTION
Currently, at every request on the application, the database driver tries to create the table `maintenance` :

```CREATE TABLE IF NOT EXISTS %s (ttl %s DEFAULT NULL)\```

This causes quite a lot of unnecessary requests to the database on a huge traffic infrastructure. I suggest to add an option to the configuration that basically says that the table is created, in which case we do not try to create it again. It can be used like this:
```
 driver:
      class: 'Lexik\Bundle\MaintenanceBundle\Drivers\DatabaseDriver'
      options: {table_created: true}
```