### PR TITLE
Use translator alias (e.g. to be able to use with lexik translation)

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="lexik_maintenance.driver.factory" class="%lexik_maintenance.driver_factory.class%" public="true">
             <argument type="service" id="lexik_maintenance.driver.database" />
-            <argument type="service" id="translator.default" />
+            <argument type="service" id="translator" />
             <argument>%lexik_maintenance.driver%</argument>
         </service>
 


### PR DESCRIPTION
Don't use Symfony's default translator but the translator configured through the translator alias.