### PR TITLE
Finish compatibility with sf4

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="lexik_maintenance.driver.factory" class="%lexik_maintenance.driver_factory.class%">
+        <service id="lexik_maintenance.driver.factory" class="%lexik_maintenance.driver_factory.class%" public="true">
             <argument type="service" id="lexik_maintenance.driver.database" />
             <argument type="service" id="translator.default" />
             <argument>%lexik_maintenance.driver%</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -31,5 +31,13 @@
             <argument>%lexik_maintenance.response.http_status%</argument>
             <argument>%kernel.debug%</argument>
         </service>
+
+        <service id="Lexik\Bundle\MaintenanceBundle\Command\DriverLockCommand" class="Lexik\Bundle\MaintenanceBundle\Command\DriverLockCommand">
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Lexik\Bundle\MaintenanceBundle\Command\DriverUnlockCommand" class="Lexik\Bundle\MaintenanceBundle\Command\DriverUnlockCommand">
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/Tests/TestHelper.php
+++ b/Tests/TestHelper.php
@@ -12,21 +12,14 @@ class TestHelper
 {
     public static function getTranslator(ContainerBuilder $container, MessageSelector $messageSelector)
     {
-        if (Kernel::VERSION_ID < 30300) {
+        if (Kernel::VERSION_ID < 30400) {
             // symfony 2
             $translator = new Translator(
                 $container,
                 $messageSelector
             );
-        } elseif (Kernel::VERSION_ID >= 30300 && Kernel::VERSION_ID < 40000) {
-            // symfony 3
-            $translator = new Translator(
-                $container,
-                $messageSelector,
-                'en'
-            );
         } else {
-            // symfony 4
+            // symfony 3, 4
             $translator = new Translator(
                 $container,
                 new MessageFormatter($messageSelector),


### PR DESCRIPTION
1. SF4 requires mark all commands as a services.
2. All services are marked as private by default. Driver factory should be marked as `public="true"` in this case.

Also, I'm prepared flex recipe for this bundle: https://github.com/symfony/recipes-contrib/pull/155.
Will merge it after merging this PR