### PR TITLE
Update documentation to avoid incorrect configuration

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -50,7 +50,8 @@ The ttl (time to life) option is optional everywhere, it is used to indicate the
 
              # File driver
             class: '\Lexik\Bundle\MaintenanceBundle\Drivers\FileDriver'                # class for file driver
-            options: {file_path: %kernel.root_dir%/../app/cache/lock}                  # file_path is the complete path for create the file
+            options: {file_path: %kernel.root_dir%/../app/cache/lock}                  # file_path is the complete path for create the file (Symfony < 3.0)
+            options: {file_path: %kernel.root_dir%/../var/cache/lock}                  # file_path is the complete path for create the file (Symfony >= 3.0)
 
              # Shared memory driver
             class: '\Lexik\Bundle\MaintenanceBundle\Drivers\ShmDriver'                 # class for shared memory driver

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -50,7 +50,7 @@ The ttl (time to life) option is optional everywhere, it is used to indicate the
 
              # File driver
             class: '\Lexik\Bundle\MaintenanceBundle\Drivers\FileDriver'                # class for file driver
-            options: {file_path: %kernel.root_dir%/cache/lock}                         # file_path is the complete path for create the file
+            options: {file_path: %kernel.root_dir%/../app/cache/lock}                  # file_path is the complete path for create the file
 
              # Shared memory driver
             class: '\Lexik\Bundle\MaintenanceBundle\Drivers\ShmDriver'                 # class for shared memory driver


### PR DESCRIPTION
According to https://symfony.com/blog/new-in-symfony-3-3-a-simpler-way-to-get-the-project-root-directory. 
Symfony sets path to kernel class in `kernel.root_dir` parameter.
1. In sf4 kernel was moved to `src/` directory, that means we need to unify configuration example to use it everywhere
2. In sf3 `cache` directory was moved into `var/` directory.

Partially related to #61 