### PR TITLE
Support for Symfony Events

### DIFF
--- a/Drivers/DriverFactory.php
+++ b/Drivers/DriverFactory.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\MaintenanceBundle\Drivers;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -29,17 +30,23 @@ class DriverFactory
      */
     protected $translator;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
     const DATABASE_DRIVER = 'Lexik\Bundle\MaintenanceBundle\Drivers\DatabaseDriver';
 
     /**
      * Constructor driver factory
      *
-     * @param DatabaseDriver      $dbDriver The databaseDriver Service
-     * @param TranslatorInterface $translator The translator service
-     * @param array               $driverOptions Options driver
+     * @param DatabaseDriver           $dbDriver        The databaseDriver Service
+     * @param TranslatorInterface      $translator      The translator service
+     * @param EventDispatcherInterface $eventDispatcher Event Dispatcher
+     * @param array                    $driverOptions   Options driver
      * @throws \ErrorException
      */
-    public function __construct(DatabaseDriver $dbDriver, TranslatorInterface $translator, array $driverOptions)
+    public function __construct(DatabaseDriver $dbDriver, TranslatorInterface $translator, EventDispatcherInterface $eventDispatcher, array $driverOptions)
     {
         $this->driverOptions = $driverOptions;
 
@@ -49,6 +56,7 @@ class DriverFactory
 
         $this->dbDriver = $dbDriver;
         $this->translator = $translator;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -73,6 +81,7 @@ class DriverFactory
         }
 
         $driver->setTranslator($this->translator);
+        $driver->setEventDispatcher($this->eventDispatcher);
 
         return $driver;
     }

--- a/Drivers/MemcachedDriver.php
+++ b/Drivers/MemcachedDriver.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Drivers;
+
+/**
+ * Class to handle a memcached driver
+ *
+ * @package LexikMaintenanceBundle
+ */
+class MemcachedDriver extends AbstractDriver implements DriverTtlInterface
+{
+    /**
+     * Value store in memcache
+     *
+     * @var string
+     */
+    const VALUE_TO_STORE = 'maintenance';
+
+    /**
+     * The key store in memcache
+     *
+     * @var string keyName
+     */
+    protected $key;
+
+    /**
+     * Memcached instance
+     *
+     * @var \Memcached
+     */
+    protected $memcached;
+
+    /**
+     * @param array $options
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $options = array())
+    {
+        parent::__construct($options);
+
+        if (isset($options['key']) === false) {
+            throw new \InvalidArgumentException('Option "key" must be defined if driver Memcached configuration is used');
+        }
+
+        if (isset($options['servers']) === false || empty($options['servers']) === true) {
+            throw new \InvalidArgumentException('Option "servers" must be defined if driver Memcached configuration is used');
+        }
+
+        $this->key = $options['key'];
+        // TODO: A configured Memcached instance should be injected into the constructor for easier testing.
+        $this->setMemcached(new \Memcached());
+        foreach ($options['servers'] as $server) {
+            if (isset($server['host']) === false) {
+                throw new \InvalidArgumentException('Option "host" must be defined for each server if driver Memcached configuration is used');
+            }
+
+            if (isset($server['port']) === false || is_int($server['port']) === false) {
+                throw new \InvalidArgumentException('Option "port" must be defined as an integer for each server if driver Memcached configuration is used');
+            }
+
+            $this->getMemcached()->addServer($server['host'], $server['port']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isExists()
+    {
+        if (false !== $this->getMemcached()->get($this->key)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageLock($resultTest)
+    {
+        $key = $resultTest ? 'lexik_maintenance.success_lock_memc' : 'lexik_maintenance.not_success_lock';
+
+        return $this->translator->trans($key, array(), 'maintenance');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageUnlock($resultTest)
+    {
+        $key = $resultTest ? 'lexik_maintenance.success_unlock' : 'lexik_maintenance.not_success_unlock';
+
+        return $this->translator->trans($key, array(), 'maintenance');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTtl($value)
+    {
+        $this->options['ttl'] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTtl()
+    {
+        return $this->options['ttl'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTtl()
+    {
+        return isset($this->options['ttl']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createLock()
+    {
+        return $this->getMemcached()->set($this->key, self::VALUE_TO_STORE, (isset($this->options['ttl']) ? $this->options['ttl'] : 0));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createUnlock()
+    {
+        return $this->getMemcached()->delete($this->key);
+    }
+
+    /**
+     * @return \Memcached
+     */
+    private function getMemcached()
+    {
+        return $this->memcached;
+    }
+
+    /**
+     * @param \Memcached $memcached
+     * @return MemcachedDriver
+     */
+    private function setMemcached($memcached)
+    {
+        $this->memcached = $memcached;
+
+        return $this;
+    }
+}

--- a/Event/AbstractEvent.php
+++ b/Event/AbstractEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class AbstractEvent
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+abstract class AbstractEvent extends Event
+{
+
+}

--- a/Event/AbstractPostEvent.php
+++ b/Event/AbstractPostEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+/**
+ * Class AbstractPostEvent
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+class AbstractPostEvent extends AbstractEvent
+{
+    /**
+     * @var bool
+     */
+    private $success;
+
+    /**
+     * PostUnlockEvent constructor.
+     *
+     * @param bool $success
+     */
+    public function __construct($success)
+    {
+        $this->setSuccess($success);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSuccess()
+    {
+        return $this->success;
+    }
+
+    /**
+     * @param bool $success
+     * @return AbstractPostEvent
+     */
+    private function setSuccess($success)
+    {
+        $this->success = $success;
+
+        return $this;
+    }
+}

--- a/Event/PostLockEvent.php
+++ b/Event/PostLockEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+/**
+ * An event dispatched just after the lock command is executed
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+class PostLockEvent extends AbstractPostEvent
+{
+    const NAME = 'maintenance-bundle.lock.post';
+}

--- a/Event/PostUnlockEvent.php
+++ b/Event/PostUnlockEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+/**
+ * An event dispatched just after the unlock command is executed
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+class PostUnlockEvent extends AbstractPostEvent
+{
+    const NAME = 'maintenance-bundle.unlock.post';
+}

--- a/Event/PreLockEvent.php
+++ b/Event/PreLockEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+/**
+ * An event dispatched just before the lock command is executed
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+class PreLockEvent extends AbstractEvent
+{
+    const NAME = 'maintenance-bundle.lock.pre';
+}

--- a/Event/PreUnlockEvent.php
+++ b/Event/PreUnlockEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Event;
+
+/**
+ * An event dispatched just before the unlock command is executed
+ *
+ * @package Lexik\Bundle\MaintenanceBundle\Event
+ */
+class PreUnlockEvent extends AbstractEvent
+{
+    const NAME = 'maintenance-bundle.unlock.pre';
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,6 +13,7 @@
         <service id="lexik_maintenance.driver.factory" class="%lexik_maintenance.driver_factory.class%" public="true">
             <argument type="service" id="lexik_maintenance.driver.database" />
             <argument type="service" id="translator.default" />
+            <argument type="service" id="event_dispatcher" />
             <argument>%lexik_maintenance.driver%</argument>
         </service>
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -99,6 +99,19 @@ Or (with the optional ttl overwriting)
 
 ---------------------
 
+### Events
+
+Events are thrown before and after locking and unlocking of the site, so that you can easily add other actions to the
+act of making the site available or not. For example, you might want to disable external site monitoring for the duration
+of your maintenance period.
+
+The events are:
+
+* `Lexik\Bundle\MaintenanceBundle\Event\PreLockEvent::NAME` - Throw just before the lock is engaged
+* `Lexik\Bundle\MaintenanceBundle\Event\PostLockEvent::NAME` - Throw just after the lock is engaged
+* `Lexik\Bundle\MaintenanceBundle\Event\PreUnlockEvent::NAME` - Throw just before the lock is removed
+* `Lexik\Bundle\MaintenanceBundle\Event\PostUnlockEvent::NAME` - Throw just after the lock is removed
+
 Custom error page 503
 ---------------------
 

--- a/Tests/Event/EventDispatcherTest.php
+++ b/Tests/Event/EventDispatcherTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Tests\Event;
+
+use Lexik\Bundle\MaintenanceBundle\Drivers\DriverFactory;
+use Lexik\Bundle\MaintenanceBundle\Event\PostLockEvent;
+use Lexik\Bundle\MaintenanceBundle\Event\PostUnlockEvent;
+use Lexik\Bundle\MaintenanceBundle\Event\PreLockEvent;
+use Lexik\Bundle\MaintenanceBundle\Event\PreUnlockEvent;
+
+class EventDispatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider createLockTestData
+     * @param bool      $exists
+     * @param bool|null $createLock
+     * @param bool      $expectedEvents
+     */
+    public function testLock($exists, $createLock, $expectedEvents)
+    {
+        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        if ($expectedEvents) {
+            $eventDispatcher->expects(self::at(0))
+                ->method('dispatch')
+                ->with(PreLockEvent::NAME, new PreLockEvent());
+
+            $eventDispatcher->expects(self::at(1))
+                ->method('dispatch')
+                ->with(PostLockEvent::NAME, new PostLockEvent($createLock));
+        }
+
+        $driver = $this->getMockBuilder('Lexik\Bundle\MaintenanceBundle\Drivers\FileDriver')->disableOriginalConstructor()->setMethods(array('isExists', 'createLock'))->getMock();
+        $driver->expects(self::any())
+            ->method('isExists')
+            ->willReturn($exists);
+        $driver->expects(self::any())
+            ->method('createLock')
+            ->willReturn($createLock);
+
+        $driver->setEventDispatcher($eventDispatcher);
+        $driver->lock();
+    }
+
+    public function createLockTestData()
+    {
+        return array(
+            'Lock exists' => array(
+                'exists' => true,
+                'createLock' => null,
+                'expectedEvents' => false,
+            ),
+            'Lock does not exists / Created successfully' => array(
+                'exists' => false,
+                'createLock' => true,
+                'expectedEvents' => true,
+            ),
+            'Lock does not exists / Not created successfully' => array(
+                'exists' => false,
+                'createLock' => true,
+                'expectedEvents' => true,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider createUnlockTestData
+     * @param $exists
+     * @param $createLock
+     * @param $expectedEvents
+     */
+    public function testUnlock($exists, $createUnlock, $expectedEvents)
+    {
+        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        if ($expectedEvents) {
+            $eventDispatcher->expects(self::at(0))
+                ->method('dispatch')
+                ->with(PreUnlockEvent::NAME, new PreUnlockEvent());
+
+            $eventDispatcher->expects(self::at(1))
+                ->method('dispatch')
+                ->with(PostUnlockEvent::NAME, new PostUnlockEvent($createUnlock));
+        }
+
+        $driver = $this->getMockBuilder('Lexik\Bundle\MaintenanceBundle\Drivers\FileDriver')->disableOriginalConstructor()->setMethods(array('isExists', 'createUnlock'))->getMock();
+        $driver->expects(self::any())
+            ->method('isExists')
+            ->willReturn($exists);
+        $driver->expects(self::any())
+            ->method('createUnlock')
+            ->willReturn($createUnlock);
+
+        $driver->setEventDispatcher($eventDispatcher);
+        $driver->unlock();
+    }
+
+    public function createUnlockTestData()
+    {
+        return array(
+            'Lock does not exists' => array(
+                'exists' => false,
+                'createUnlock' => null,
+                'expectedEvents' => false,
+            ),
+            'Lock exists / Created successfully' => array(
+                'exists' => true,
+                'createUnlock' => true,
+                'expectedEvents' => true,
+            ),
+            'Lock exists / Not created successfully' => array(
+                'exists' => true,
+                'createUnlock' => true,
+                'expectedEvents' => true,
+            ),
+        );
+    }
+
+    /**
+     * @param array $mocks
+     * @param array $driverOptions
+     * @return DriverFactory
+     * @throws \ErrorException
+     */
+    public function createDriverFactory(array $mocks = array(), array $driverOptions = array())
+    {
+        $dbDriver = array_key_exists('dbDriver', $mocks) ? $mocks['dbDriver'] : $this->getMockBuilder('Lexik\Bundle\MaintenanceBundle\Drivers\DatabaseDriver')->disableOriginalConstructor()->getMock();
+        $translator = array_key_exists('translator', $mocks) ? $mocks['translator'] : $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+        $eventDispatcher = array_key_exists('eventDispatcher', $mocks) ? $mocks['eventDispatcher'] : $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+
+        return new DriverFactory($dbDriver, $translator, $eventDispatcher, $driverOptions);
+    }
+}

--- a/Tests/EventListener/MaintenanceListenerTest.php
+++ b/Tests/EventListener/MaintenanceListenerTest.php
@@ -38,7 +38,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(false),$this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(false), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory);
@@ -47,7 +47,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new MaintenanceListenerTestWrapper($this->factory, 'path', 'host', array('ip'), array('query'), array('cookie'), 'route');
         $this->assertTrue($listener->onKernelRequest($event), 'Permissive factory should approve with args');
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory);
@@ -72,7 +72,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null);
@@ -103,7 +103,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null, null);
@@ -137,7 +137,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null, null, null);
@@ -171,7 +171,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null, null, null, array(), array(), $debug);
@@ -219,7 +219,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null, null, null, null);
@@ -259,7 +259,7 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(true), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
 
         $listener = new MaintenanceListenerTestWrapper($this->factory, null, null, null, null, null);
@@ -343,5 +343,13 @@ class MaintenanceListenerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         return TestHelper::getTranslator($this->container, $messageSelector);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    public function getEventDispatcher()
+    {
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
     }
 }

--- a/Tests/Maintenance/DriverFactoryTest.php
+++ b/Tests/Maintenance/DriverFactoryTest.php
@@ -27,7 +27,7 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->container = $this->initContainer();
 
-        $this->factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $driverOptions);
+        $this->factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $this->factory);
     }
 
@@ -47,14 +47,14 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionConstructor()
     {
-        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), array());
+        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $this->getEventDispatcher(), array());
     }
 
     public function testWithDatabaseChoice()
     {
         $driverOptions = array('class' => DriverFactory::DATABASE_DRIVER, 'options' => null);
 
-        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $driverOptions);
+        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
 
         $this->container->set('lexik_maintenance.driver.factory', $factory);
 
@@ -65,7 +65,7 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $driverOptions = array('class' => '\Unknown', 'options' => null);
 
-        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $driverOptions);
+        $factory = new DriverFactory($this->getDatabaseDriver(), $this->getTranslator(), $this->getEventDispatcher(), $driverOptions);
         $this->container->set('lexik_maintenance.driver.factory', $factory);
 
         try {
@@ -108,5 +108,13 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         return TestHelper::getTranslator($this->container, $messageSelector);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    public function getEventDispatcher()
+    {
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
     }
 }

--- a/Tests/Maintenance/FileMaintenanceTest.php
+++ b/Tests/Maintenance/FileMaintenanceTest.php
@@ -78,6 +78,7 @@ class FileMaintenanceTest extends TestCase
 
         $fileM = new FileDriver($options);
         $fileM->setTranslator($this->getTranslator());
+        $fileM->setEventDispatcher($this->getEventDispatcher());
         $fileM->lock();
 
         $fileM->unlock();
@@ -91,6 +92,7 @@ class FileMaintenanceTest extends TestCase
 
         $fileM = new FileDriver($options);
         $fileM->setTranslator($this->getTranslator());
+        $fileM->setEventDispatcher($this->getEventDispatcher());
         $fileM->lock();
 
         $this->assertTrue($fileM->isEndTime(3600));
@@ -102,6 +104,7 @@ class FileMaintenanceTest extends TestCase
 
         $fileM = new FileDriver($options);
         $fileM->setTranslator($this->getTranslator());
+        $fileM->setEventDispatcher($this->getEventDispatcher());
         $fileM->lock();
 
         // lock
@@ -140,5 +143,13 @@ class FileMaintenanceTest extends TestCase
             ->getMock();
 
         return TestHelper::getTranslator($this->container, $messageSelector);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    public function getEventDispatcher()
+    {
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
     }
 }

--- a/Tests/Maintenance/MemcachedTest.php
+++ b/Tests/Maintenance/MemcachedTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Lexik\Bundle\MaintenanceBundle\Tests\Maintenance;
+
+use Lexik\Bundle\MaintenanceBundle\Drivers\MemcachedDriver;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use Lexik\Bundle\MaintenanceBundle\Drivers\MemCacheDriver;
+
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+
+/**
+ * Test memcached
+ *
+ * @package LexikMaintenanceBundle
+ */
+class MemcachedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructWithNotKeyName()
+    {
+        $memC = new MemcachedDriver(array());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructWithNotHost()
+    {
+        $memC = new MemcachedDriver(array('key_name' => 'mnt'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructWithNotPort()
+    {
+        $memC = new MemcachedDriver(array('key_name' => 'mnt', 'host' => '127.0.0.1'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructWithNotPortNumber()
+    {
+        $memC = new MemcachedDriver(array('key_name' => 'mnt', 'host' => '127.0.0.1', 'port' => 'roti'));
+    }
+
+    protected function initContainer()
+    {
+        $container = new ContainerBuilder(new ParameterBag(array(
+            'kernel.debug'          => false,
+            'kernel.bundles'        => array('MaintenanceBundle' => 'Lexik\Bundle\MaintenanceBundle'),
+            'kernel.cache_dir'      => sys_get_temp_dir(),
+            'kernel.environment'    => 'dev',
+            'kernel.root_dir'       => __DIR__.'/../../../../', // src dir
+            'kernel.default_locale' => 'fr',
+        )));
+
+        return $container;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,18 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/framework-bundle": "~2.7|~3.0|^4.0",
-        "symfony/translation": "~2.7|~3.0|^4.0"
+        "symfony/translation": "~2.7|~3.0|^4.0",
+        "symfony/event-dispatcher": "~2.7|~3.0|^4.0",
+        "symfony/console": "~2.7|~3.0|^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0|^4.0",
-        "phpunit/phpunit": "~4.8|~5.7.11"
+        "phpunit/phpunit": "~4.8|~5.7.11",
+        "doctrine/doctrine-bundle": "^1.0"
+    },
+    "suggest": {
+        "doctrine/doctrine-bundle": "For database site locking",
+        "ext-memcache": "For memcache site locking"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\MaintenanceBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For database site locking",
-        "ext-memcache": "For memcache site locking"
+        "ext-memcache": "For memcache site locking - Probably don't use this as the ext-memcache has been superseded by ext-memcached",
+        "ext-memcached": "For memcached site locking"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\MaintenanceBundle\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,11 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <!-- Added this to stop it complaining about the deprecated Symfony\Component\Translation\MessageSelector in a test -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="1"/>
+    </php>
+
     <testsuites>
         <testsuite name="LexikMaintenanceBundle Test Suite">
             <directory>./Tests/</directory>


### PR DESCRIPTION
Hi there. I've added a some simple events to the bundle so that people can trigger other actions from locking and unlocking the site.

Use case: Currently, when I take a site off-line, all external monitoring goes red and people start shouting at me about the site being down. So I want to be able to disable external systems on successfully locking the site and then enable them once the site is back.

Currently, the events are pretty rudimentary, but could be extended to contain extra information if required in the future.

Hope you find this useful and accept the pull. ;-)