### PR TITLE
Replace ContainerAwareCommand usages with DI

### DIFF
--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -3,12 +3,12 @@
 namespace Lexik\Bundle\MaintenanceBundle\Command;
 
 use Lexik\Bundle\MaintenanceBundle\Drivers\AbstractDriver;
+use Lexik\Bundle\MaintenanceBundle\Drivers\DriverFactory;
 use Lexik\Bundle\MaintenanceBundle\Drivers\DriverTtlInterface;
-
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
 /**
  * Create a lock action
@@ -16,9 +16,18 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
  * @package LexikMaintenanceBundle
  * @author  Gilles Gauthier <g.gauthier@lexik.fr>
  */
-class DriverLockCommand extends ContainerAwareCommand
+class DriverLockCommand extends Command
 {
     protected $ttl;
+
+    /** @var DriverFactory */
+    private $driverFactory;
+
+    public function __construct(DriverFactory $driverFactory)
+    {
+        parent::__construct();
+        $this->driverFactory = $driverFactory;
+    }
 
     /**
      * {@inheritdoc}
@@ -137,7 +146,7 @@ EOT
      */
     private function getDriver()
     {
-        return $this->getContainer()->get('lexik_maintenance.driver.factory')->getDriver();
+        return $this->driverFactory->getDriver();
     }
 
     /**

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -2,9 +2,10 @@
 
 namespace Lexik\Bundle\MaintenanceBundle\Command;
 
+use Lexik\Bundle\MaintenanceBundle\Drivers\DriverFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
 /**
  * Create an unlock action
@@ -12,8 +13,17 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
  * @package LexikMaintenanceBundle
  * @author  Gilles Gauthier <g.gauthier@lexik.fr>
  */
-class DriverUnlockCommand extends ContainerAwareCommand
+class DriverUnlockCommand extends Command
 {
+    /** @var DriverFactory */
+    private $driverFactory;
+
+    public function __construct(DriverFactory $driverFactory)
+    {
+        parent::__construct();
+        $this->driverFactory = $driverFactory;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -39,7 +49,7 @@ EOT
             return;
         }
 
-        $driver = $this->getContainer()->get('lexik_maintenance.driver.factory')->getDriver();
+        $driver = $this->driverFactory->getDriver();
 
         $unlockMessage = $driver->getMessageUnlock($driver->unlock());
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,10 +34,12 @@
         </service>
 
         <service id="Lexik\Bundle\MaintenanceBundle\Command\DriverLockCommand" class="Lexik\Bundle\MaintenanceBundle\Command\DriverLockCommand">
+            <argument type="service" id="lexik_maintenance.driver.factory" />
             <tag name="console.command"/>
         </service>
 
         <service id="Lexik\Bundle\MaintenanceBundle\Command\DriverUnlockCommand" class="Lexik\Bundle\MaintenanceBundle\Command\DriverUnlockCommand">
+            <argument type="service" id="lexik_maintenance.driver.factory" />
             <tag name="console.command"/>
         </service>
     </services>


### PR DESCRIPTION
> The "Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand" class is deprecated since Symfony 4.2, use "Symfony\Component\Console\Command\Command" with dependency injection instead.

This PR is meant to fix that