### PR TITLE
Maintenance listener throwing deprecation exception on PHP 7.4 in dev environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
   - hhvm
 
 sudo: false
@@ -28,6 +30,10 @@ matrix:
     - php: 7.1
       env: DEPENDENCIES=beta
     - php: 7.2
+      env: DEPENDENCIES=beta
+    - php: 7.3
+      env: DEPENDENCIES=beta
+    - php: 7.4
       env: DEPENDENCIES=beta
 
 before_install:

--- a/Listener/MaintenanceListener.php
+++ b/Listener/MaintenanceListener.php
@@ -194,7 +194,10 @@ class MaintenanceListener
         }
 
         $route = $request->get('_route');
-        if (null !== $this->route && preg_match('{'.$this->route.'}', $route)  || (true === $this->debug && '_' === $route[0])) {
+        if ($route && (
+            (null !== $this->route && preg_match('{' . $this->route . '}', $route)) ||
+            (true === $this->debug && '_' === $route[0])
+        )) {
             return;
         }
 


### PR DESCRIPTION
**Deprecation type**: `Trying to access array offset on value of type null`.

**Steps to reproduce**:
- change priority of the MaintenanceListener to execute in before Symfony`s RouteListener (must be empty `_route` in the Request)
- use PHP 7.4
- execute application in dev mode
- enable E_ALL `error_reporting` in the `php.ini`

Additional info: https://wiki.php.net/rfc/notice-for-non-valid-array-container
