### PR TITLE
removed symfony 4.4 deprecations

### DIFF
--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -5,10 +5,10 @@ namespace Lexik\Bundle\MaintenanceBundle\Command;
 use Lexik\Bundle\MaintenanceBundle\Drivers\AbstractDriver;
 use Lexik\Bundle\MaintenanceBundle\Drivers\DriverTtlInterface;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
 /**
  * Create a lock action
@@ -16,7 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
  * @package LexikMaintenanceBundle
  * @author  Gilles Gauthier <g.gauthier@lexik.fr>
  */
-class DriverLockCommand extends ContainerAwareCommand
+class DriverLockCommand extends Command
 {
     protected $ttl;
 

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -2,9 +2,9 @@
 
 namespace Lexik\Bundle\MaintenanceBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
 /**
  * Create an unlock action
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
  * @package LexikMaintenanceBundle
  * @author  Gilles Gauthier <g.gauthier@lexik.fr>
  */
-class DriverUnlockCommand extends ContainerAwareCommand
+class DriverUnlockCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,8 +20,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('lexik_maintenance');
+        $treeBuilder = new TreeBuilder('lexik_maintenance');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->addDefaultsIfNotSet()


### PR DESCRIPTION
changed Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand to Symfony\Component\Console\Command\Command

changed contructor of the Configuration Tree Builder
